### PR TITLE
CORS is enabled by default

### DIFF
--- a/express.js
+++ b/express.js
@@ -3,16 +3,7 @@ const express = require('express')
 
 let slsExpress = () => implement(express())
 Object.setPrototypeOf(slsExpress, express)
-module.exports = slsExpress
-
-
-
-
-
-
-
-
-
+module.exports = slsExpress 
 
 function implement(app){
     switch( process.env.SERVERLESS_EXPRESS_PLATFORM ){

--- a/express.js
+++ b/express.js
@@ -6,6 +6,11 @@ Object.setPrototypeOf(slsExpress, express)
 module.exports = slsExpress 
 
 function implement(app){
+    app.use((req, res, next)=>{
+        res.append('Access-Control-Allow-Origin', '*');
+        next()
+    })    
+
     switch( process.env.SERVERLESS_EXPRESS_PLATFORM ){
         case 'aws': return aws_express(app);
         case 'google': return google_express(app);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-express",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Run express apps on AWS λ easily.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-express",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Run express apps on AWS λ easily.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
by doing so, it fixes a bug "Authentication Missing" that happens with AWS.
it's preferable to enable it by default and let the user modify it afterward if needed.