### PR TITLE
Do not rely on `serverless.variables`

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ module.exports = class ServerlessExpressPlugin {
   constructor(serverless, options) {
     this.serverless = serverless
 
-    this.serverless.variables.service.provider.environment = this.serverless.variables.service.provider.environment || {}
-    this.environment = this.serverless.variables.service.provider.environment
-    this.providerName = this.serverless.variables.service.provider.name
+    this.serverless.service.provider.environment = this.serverless.service.provider.environment || {}
+    this.environment = this.serverless.service.provider.environment
+    this.providerName = this.serverless.service.provider.name
 
     // set environment variable SERVERLESS_EXPRESS_PLATFORM to aws, azure, google, etc
     this._initialize()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-express",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Run express apps on AWS λ easily.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`serverless.variables` will be gone with v3 release of a Framework, while `service` can be accessed at `serverless.service`

This patch ensures that plugin remains working with v3